### PR TITLE
Usunięcie Short Tag

### DIFF
--- a/src/Allegro.php
+++ b/src/Allegro.php
@@ -1,4 +1,4 @@
-<?
+<?php
 namespace Allegro;
 
 class Allegro 


### PR DESCRIPTION
Przy nowszej wersji PHP i standardowo wyłączonych short tagach jest problem z załadowaniem klasy.
