### PR TITLE
Umozliwienie wywolania metod bezargumentowych

### DIFF
--- a/src/Allegro.php
+++ b/src/Allegro.php
@@ -69,6 +69,20 @@ class Allegro
         $this->session = $this->client->doLoginWithAccessToken($request);
     }
 
+    /**
+     * Pobierz klienta SoapClient
+     * 
+     * Umozliwienie wywolania metod bezargumentowych 
+     * (bez dodawania elementow sesjii allegro) 
+     * np.: $Allegro->client()->__getLastRequest();
+     * 
+     * @return \SoapClient
+     */
+    public function client()
+    {
+        return $this->client;
+    }
+
     public function __call($name, $arguments)
     {
         if(isset($arguments[0])) $arguments = (array)$arguments[0];


### PR DESCRIPTION
Aby pobrać ostatni request SOAP konieczne jest wywołanie metody __getLastRequest() bez żadnych argumentów.
Nie można tego aktualnie wykonać metodą __send(), ponieważ dodaje ona elementu sesji allegro jako argument.